### PR TITLE
Update to work with the latest slackin and Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:5-slim
 
 RUN apt-get -y update
-RUN apt-get -y install nginx
+RUN apt-get -y install nginx build-essential
 RUN npm install -g slackin
 
 COPY conf/nginx.conf /etc/nginx/nginx.conf

--- a/bin/launch
+++ b/bin/launch
@@ -3,5 +3,5 @@
 nginx -g "daemon off;" &
 slackin "${SLACK_SUBDOMAIN:?SLACK_SUBDOMAIN must be set}" \
         "${SLACK_TOKEN:?SLACK_TOKEN must be set}" \
-        --interval 30000 \
+	      -h 0.0.0.0 \
         -p 3000


### PR DESCRIPTION
The latest Slackin releases requires `build-essential` to be installed and the latest Docker requires us to manually tell it to host on `0.0.0.0`.
